### PR TITLE
Discord.js v12+ fix

### DIFF
--- a/reposter.js
+++ b/reposter.js
@@ -455,7 +455,7 @@ async function repostLive(message) {
 
 function sendCommands(channel) {
 	const prefix = config.prefixes[(channel.guild || channel).id] || "/";
-	const rich = new Discord.RichEmbed();
+	const rich = new Discord.MessageEmbed();
 	rich.setTitle("Reposter Commands");
 	rich.setDescription("By MysteryPancake");
 	rich.setFooter(client.user.id, client.user.displayAvatarURL);


### PR DESCRIPTION
The old code doesn't work with new Discord.js, throws a `Discord.RichEmbed is not a constructor` error. This oneliner PR fixes this.